### PR TITLE
Minor fixes in pkg/api/v2. 

### DIFF
--- a/pkg/api/v2/config.go
+++ b/pkg/api/v2/config.go
@@ -83,7 +83,7 @@ type RouterConfigurationConfig struct {
 	RequestHeadersToAdd     []*HeaderValueOption `json:"request_headers_to_add,omitempty"`
 	ResponseHeadersToAdd    []*HeaderValueOption `json:"response_headers_to_add,omitempty"`
 	ResponseHeadersToRemove []string             `json:"response_headers_to_remove,omitempty"`
-	RouterConfigPath        string               `json:"router_configs, omitempty"`
+	RouterConfigPath        string               `json:"router_configs,omitempty"`
 	StaticVirtualHosts      []*VirtualHost       `json:"virtual_hosts,omitempty"`
 }
 

--- a/pkg/api/v2/types.go
+++ b/pkg/api/v2/types.go
@@ -25,8 +25,8 @@ import (
 	"path"
 	"time"
 
-	"sofastack.io/sofa-mosn/pkg/utils"
 	"istio.io/api/mixer/v1/config/client"
+	"sofastack.io/sofa-mosn/pkg/utils"
 )
 
 // Metadata field can be used to provide additional information about the route.
@@ -384,7 +384,7 @@ type TLSConfig struct {
 	MaxVersion   string                 `json:"max_version,omitempty"`
 	ALPN         string                 `json:"alpn,omitempty"`
 	Ticket       string                 `json:"ticket,omitempty"`
-	Fallback     bool                   `json:"fall_back, omitempty"`
+	Fallback     bool                   `json:"fall_back"`
 	ExtendVerify map[string]interface{} `json:"extend_verify,omitempty"`
 }
 


### PR DESCRIPTION
Specifically, 1) removed unnecessary space ahead of omitempty; 2) reordered the import file in an alphabet order.

### Issues associated with this PR

N/A

### Sign the CLA
Make sure you have signed the [CLA](https://www.clahub.com/agreements/alipay/sofa-mosn)

### Solutions

N/A

### UT result

N/A

### Benchmark

N/A

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
