### PR TITLE
Minor bug fixes in unit tests.

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -25,9 +25,9 @@ import (
 	"strings"
 	"testing"
 
-	"sofastack.io/sofa-mosn/pkg/api/v2"
-	"sofastack.io/sofa-mosn/pkg/types"
 	jsoniter "github.com/json-iterator/go"
+	v2 "sofastack.io/sofa-mosn/pkg/api/v2"
+	"sofastack.io/sofa-mosn/pkg/types"
 )
 
 func TestClusterConfigParse(t *testing.T) {
@@ -49,7 +49,7 @@ func TestClusterConfigParse(t *testing.T) {
 	}
 	// verify
 	if len(testConfig.ClusterManager.Clusters) != 2 {
-		t.Fatal("cluster parsed not enough, got : %v", testConfig.ClusterManager.Clusters)
+		t.Fatalf("cluster parsed not enough, got : %v", testConfig.ClusterManager.Clusters)
 	}
 }
 
@@ -87,7 +87,7 @@ func TestClusterConfigDynamicModeParse(t *testing.T) {
 	}
 	// verify
 	if len(testConfig.ClusterManager.Clusters) != 2 {
-		t.Fatal("cluster parsed not enough, got : %v", testConfig.ClusterManager.Clusters)
+		t.Fatalf("cluster parsed not enough, got : %v", testConfig.ClusterManager.Clusters)
 	}
 	// add a new cluster
 	testConfig.ClusterManager.Clusters = append(testConfig.ClusterManager.Clusters, v2.Cluster{
@@ -239,13 +239,13 @@ func BenchmarkConfigMarshal(b *testing.B) {
 		os.MkdirAll(clusterPath, 0755)
 		for i := 0; i < b.N; i++ {
 			if _, err := _iterJson.Marshal(conf); err != nil {
-				b.Fatal("json-iterator marshal json error: %v", err)
+				b.Fatalf("json-iterator marshal json error: %v", err)
 			}
 		}
 		// verify
 		files, err := ioutil.ReadDir(clusterPath)
 		if err != nil {
-			b.Fatal("json-iterator verify cluster path failed: %v", err)
+			b.Fatalf("json-iterator verify cluster path failed: %v", err)
 		}
 		if len(files) != 5000 {
 			b.Fatal("json-iterator cluster count is not expected")
@@ -257,13 +257,13 @@ func BenchmarkConfigMarshal(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
 			if _, err := json.Marshal(conf); err != nil {
-				b.Fatal("std json marshal json error: %v", err)
+				b.Fatalf("std json marshal json error: %v", err)
 			}
 		}
 		// verify
 		files, err := ioutil.ReadDir(clusterPath)
 		if err != nil {
-			b.Fatal("std json verify cluster path failed: %v", err)
+			b.Fatalf("std json verify cluster path failed: %v", err)
 		}
 		if len(files) != 5000 {
 			b.Fatal("std json cluster count is not expected")

--- a/pkg/config/configmanager_test.go
+++ b/pkg/config/configmanager_test.go
@@ -22,7 +22,7 @@ import (
 	"reflect"
 	"testing"
 
-	"sofastack.io/sofa-mosn/pkg/api/v2"
+	v2 "sofastack.io/sofa-mosn/pkg/api/v2"
 )
 
 func mockInitConfig(t *testing.T, cfg []byte) {
@@ -146,7 +146,7 @@ func TestUpdateStreamFilter(t *testing.T) {
 		}
 		ver := v.(string)
 		if ver != "2.0" {
-			t.Error("%s stream filter config update not expected", name)
+			t.Errorf("%s stream filter config update not expected", name)
 		}
 	}
 }

--- a/pkg/metrics/store_test.go
+++ b/pkg/metrics/store_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+
 	gometrics "github.com/rcrowley/go-metrics"
 	"sofastack.io/sofa-mosn/pkg/metrics/shm"
 )
@@ -110,7 +111,7 @@ func TestExclusionLabels(t *testing.T) {
 		typ := fmt.Sprintf("test%d", i)
 		m, _ := NewMetrics(typ, tc.labels)
 		if _, ok := m.(*NilMetrics); !ok {
-			t.Errorf("#%d expected get nil metrics, but not")
+			t.Error("expected get nil metrics, but it is not")
 		}
 	}
 }

--- a/pkg/server/adapter_test.go
+++ b/pkg/server/adapter_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"sofastack.io/sofa-mosn/pkg/api/v2"
+	v2 "sofastack.io/sofa-mosn/pkg/api/v2"
 	"sofastack.io/sofa-mosn/pkg/types"
 )
 
@@ -67,7 +67,7 @@ func baseListenerConfig(addrStr string, name string) *v2.Listener {
 				},
 			}, //no stream filters parsed, but the config still exists for test
 		},
-		Addr: addr,
+		Addr:                    addr,
 		PerConnBufferLimitBytes: 1 << 15,
 	}
 }
@@ -82,7 +82,7 @@ func TestLDS(t *testing.T) {
 		&mockNetworkFilterFactory{},
 	}
 	if err := GetListenerAdapterInstance().AddOrUpdateListener(testServerName, listenerConfig, nfcfs, nil); err != nil {
-		t.Fatalf("add a new listener failed", err)
+		t.Fatalf("add a new listener failed %v", err)
 	}
 	time.Sleep(time.Second) // wait listener start
 	// verify
@@ -130,7 +130,7 @@ func TestLDS(t *testing.T) {
 			StreamFilters: []v2.Filter{}, // stream filter will not be updated
 			Inspector:     true,
 		},
-		Addr: listenerConfig.Addr, // addr should not be changed
+		Addr:                    listenerConfig.Addr, // addr should not be changed
 		PerConnBufferLimitBytes: 1 << 10,
 	}
 	if err := GetListenerAdapterInstance().AddOrUpdateListener(testServerName, newListenerConfig, nil, nil); err != nil {
@@ -192,7 +192,7 @@ func TestUpdateTLS(t *testing.T) {
 		&mockNetworkFilterFactory{},
 	}
 	if err := GetListenerAdapterInstance().AddOrUpdateListener(testServerName, listenerConfig, nfcfs, nil); err != nil {
-		t.Fatalf("add a new listener failed", err)
+		t.Fatalf("add a new listener failed %v", err)
 	}
 	time.Sleep(time.Second) // wait listener start
 	tlsCfg := v2.TLSConfig{
@@ -210,7 +210,7 @@ func TestUpdateTLS(t *testing.T) {
 		conn.Close()
 	}
 	if err := GetListenerAdapterInstance().UpdateListenerTLS(testServerName, name, false, []v2.TLSConfig{tlsCfg}); err != nil {
-		t.Fatalf("update tls listener failed", err)
+		t.Fatalf("update tls listener failed %v", err)
 	}
 	handler := listenerAdapterInstance.defaultConnHandler.(*connHandler)
 	newLn := handler.FindListenerByName(name)

--- a/pkg/stream/sofarpc/keepalive_test.go
+++ b/pkg/stream/sofarpc/keepalive_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"sofastack.io/sofa-mosn/pkg/api/v2"
+	v2 "sofastack.io/sofa-mosn/pkg/api/v2"
 	"sofastack.io/sofa-mosn/pkg/protocol"
 	"sofastack.io/sofa-mosn/pkg/protocol/rpc/sofarpc"
 	str "sofastack.io/sofa-mosn/pkg/stream"
@@ -73,7 +73,7 @@ func newTestCase(t *testing.T, srvTimeout, keepTimeout time.Duration, thres uint
 	ctx := context.Background()
 	conn := host.CreateConnection(ctx)
 	if err := conn.Connection.Connect(true); err != nil {
-		t.Fatalf("create conenction failed", err)
+		t.Fatalf("create conenction failed %v", err)
 	}
 	codec := str.NewStreamClient(ctx, protocol.SofaRPC, conn.Connection, host)
 	if codec == nil {


### PR DESCRIPTION
### Issues associated with this PR

Specifically, whenever running make, it emits the following errors/warnings:

pkg/config/config_test.go:52:3: Fatal call has possible formatting directive %v
pkg/config/config_test.go:90:3: Fatal call has possible formatting directive %v
pkg/config/config_test.go:242:5: Fatal call has possible formatting directive %v
pkg/config/config_test.go:248:4: Fatal call has possible formatting directive %v
pkg/config/config_test.go:260:5: Fatal call has possible formatting directive %v
pkg/config/config_test.go:266:4: Fatal call has possible formatting directive %v
pkg/config/configmanager_test.go:149:4: Error call has possible formatting directive %s
# sofastack.io/sofa-mosn/pkg/metrics
pkg/metrics/store_test.go:113:4: Errorf format %d reads arg #1, but call has 0 args
# sofastack.io/sofa-mosn/pkg/server
pkg/server/adapter_test.go:85:11: Fatalf call has arguments but no formatting directives
pkg/server/adapter_test.go:195:11: Fatalf call has arguments but no formatting directives
pkg/server/adapter_test.go:213:11: Fatalf call has arguments but no formatting directives
# sofastack.io/sofa-mosn/pkg/stream/sofarpc
pkg/stream/sofarpc/keepalive_test.go:76:11: Fatalf call has arguments but no formatting directives

### Sign the CLA
Make sure you have signed the [CLA](https://www.clahub.com/agreements/alipay/sofa-mosn)

### Solutions

N/A

### UT result

N/A


### Benchmark

N/A

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
