### PR TITLE
fix onResponseTimeout() causes panic

### DIFF
--- a/pkg/proxy/downstream.go
+++ b/pkg/proxy/downstream.go
@@ -763,7 +763,6 @@ func (s *downStream) onResponseTimeout() {
 			log.Proxy.Errorf(s.context, "[proxy] [downstream] onResponseTimeout() panic %v\n%s", r, string(debug.Stack()))
 		}
 	}()
-	s.responseTimer = nil
 	s.cluster.Stats().UpstreamRequestTimeout.Inc(1)
 
 	if s.upstreamRequest != nil {
@@ -811,7 +810,6 @@ func (s *downStream) onPerReqTimeout() {
 	if !s.downstreamResponseStarted {
 		// handle timeout on response not
 
-		s.perRetryTimer = nil
 		s.cluster.Stats().UpstreamRequestTimeout.Inc(1)
 
 		if s.upstreamRequest.host != nil {


### PR DESCRIPTION
### Issues associated with this PR

Your PR should present related issues you want to solve.

### Sign the CLA
Make sure you have signed the [CLA](https://www.clahub.com/agreements/alipay/sofa-mosn)

### Solutions
When OnResponseTimeout and process response trigger at the same time, it may happen that response first processed and cleared the data, causes OnResponseTimeout to panic.
fix: When OnResponseTimeout trigger, set reuseBuffer false, and don't clear data.


### UT result
Unit Test is needed if the code is changed, your unit test should cover boundary cases, corner cases, and some exceptional cases.
And you need to show the ut result.

### Benchmark
If your code involves the processing of every request, you should give the Benchmark Result

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
