### PR TITLE
fix(http): deal with stream reset/destroy properly

### DIFF
--- a/pkg/network/connection.go
+++ b/pkg/network/connection.go
@@ -366,6 +366,9 @@ func (c *connection) doRead() (err error) {
 	bytesRead, err = c.readBuffer.ReadOnce(c.rawConnection)
 
 	if err != nil {
+		if atomic.LoadUint32(&c.closed) == 1 {
+			return nil
+		}
 		if te, ok := err.(net.Error); ok && te.Timeout() {
 			for _, cb := range c.connCallbacks {
 				cb.OnEvent(types.OnReadTimeout) // run read timeout callback, for keep alive if configured
@@ -573,6 +576,9 @@ func (c *connection) appendBuffer(iobuffers *[]types.IoBuffer) {
 
 func (c *connection) doWrite() (int64, error) {
 	bytesSent, err := c.doWriteIo()
+	if err != nil && atomic.LoadUint32(&c.closed) == 1 {
+		return 0, nil
+	}
 
 	c.updateWriteBuffStats(bytesSent, int64(c.writeBufLen()))
 

--- a/pkg/stream/http/stream.go
+++ b/pkg/stream/http/stream.go
@@ -116,6 +116,7 @@ type streamConnection struct {
 
 	conn              types.Connection
 	connEventListener types.ConnectionEventListener
+	resetReason       types.StreamResetReason
 
 	bufChan    chan types.IoBuffer
 	connClosed chan bool
@@ -218,7 +219,11 @@ func (conn *clientStreamConnection) serve() {
 		if err != nil {
 			if s != nil {
 				log.Proxy.Errorf(s.connection.context, "[stream] [http] client stream connection wait response error: %s", err)
-				s.ResetStream(types.StreamRemoteReset)
+				reason := conn.resetReason
+				if reason == "" {
+					reason = types.StreamRemoteReset
+				}
+				s.ResetStream(reason)
 			}
 			return
 		}
@@ -280,6 +285,7 @@ func (conn *clientStreamConnection) ActiveStreamsNum() int {
 func (conn *clientStreamConnection) Reset(reason types.StreamResetReason) {
 	close(conn.bufChan)
 	close(conn.connClosed)
+	conn.resetReason = reason
 }
 
 // types.ServerStreamConnection


### PR DESCRIPTION
just close http client upstream connection when downstream reset,
or the connection should wait the last response if exist even not pooled immediately,
and the fix in PR: #698 will lead to connections leak.

connections closed locally should not spread read/write error
which will lead to another close.