### PR TITLE
http body recycle

### DIFF
--- a/pkg/network/connection.go
+++ b/pkg/network/connection.go
@@ -163,7 +163,7 @@ func (c *connection) attachEventLoop(lctx context.Context) {
 	// Choose one event loop to register, the implement is platform-dependent(epoll for linux and kqueue for bsd)
 	c.eventLoop = attach()
 
-	// Register read only, write is supported now because it is more complex than read.
+	// Register read only, write is not supported now because it is more complex than read.
 	// We need to write our own code based on syscall.write to deal with the EAGAIN and writable epoll event
 	err := c.eventLoop.registerRead(c, &connEventHandler{
 		onRead: func() bool {

--- a/pkg/stream/http/stream.go
+++ b/pkg/stream/http/stream.go
@@ -485,6 +485,8 @@ func (s *clientStream) AppendHeaders(context context.Context, headersIn types.He
 
 func (s *clientStream) AppendData(context context.Context, data types.IoBuffer, endStream bool) error {
 	s.request.SetBody(data.Bytes())
+	// dec data's ref, so we can recycle it
+	buffer.PutIoBuffer(data)
 
 	if endStream {
 		s.endStream()
@@ -605,6 +607,8 @@ func (s *serverStream) AppendHeaders(context context.Context, headersIn types.He
 
 func (s *serverStream) AppendData(context context.Context, data types.IoBuffer, endStream bool) error {
 	s.response.SetBody(data.Bytes())
+	// dec data's ref, so we can recycle it
+	buffer.PutIoBuffer(data)
 
 	if endStream {
 		s.endStream()


### PR DESCRIPTION
## problem

can not recycle downstream.downstreamReqDataBuf in http scene. The reference counting is not balanced.

Typical Scene:

inc timing: 
1. alloc from pool  
2. on receive data

dec timing:
1. connection Write(missing in http scene)
2. downstream cleanStream

## solution

Add extra code to dec the ref.

```go
func (s *clientStream) AppendData(context context.Context, data types.IoBuffer, endStream bool) error {
	s.request.SetBody(data.Bytes())
	// dec data's ref, so we can recycle it
+++	buffer.PutIoBuffer(data)

	if endStream {
		s.endStream()
	}

	return nil
}
```


