### PR TITLE
Xds init opportunity

### DIFF
--- a/pkg/mosn/starter.go
+++ b/pkg/mosn/starter.go
@@ -177,8 +177,11 @@ func NewMosn(c *config.MOSNConfig, serviceCluster string, serviceNode string) *M
 	}
 
 	//xds
-	m.xdsClient = xds.Client{}
-	m.xdsClient.Start(c, serviceCluster, serviceNode)
+	if serviceCluster != "" && serviceNode != "" {
+		m.xdsClient = xds.Client{}
+		m.xdsClient.Start(c, serviceCluster, serviceNode)
+	}
+
 	//parse service registry info
 	config.ParseServiceRegistry(c.ServiceRegistry)
 

--- a/test/fuzzy/random.go
+++ b/test/fuzzy/random.go
@@ -73,7 +73,7 @@ func FuzzyClient(stop chan struct{}, client Client) {
 func CreateMeshProxy(t *testing.T, stop chan struct{}, serverList []string, proto types.Protocol) string {
 	meshAddr := util.CurrentMeshAddr()
 	cfg := util.CreateProxyMesh(meshAddr, serverList, proto)
-	mesh := mosn.NewMosn(cfg)
+	mesh := mosn.NewMosn(cfg, "", "")
 	go mesh.Start()
 	go func() {
 		<-stop
@@ -87,7 +87,7 @@ func CreateMeshCluster(t *testing.T, stop chan struct{}, serverList []string, ap
 	meshAddr := util.CurrentMeshAddr()
 	meshServerAddr := util.CurrentMeshAddr()
 	cfg := util.CreateMeshToMeshConfig(meshAddr, meshServerAddr, appproto, meshproto, serverList, false)
-	mesh := mosn.NewMosn(cfg)
+	mesh := mosn.NewMosn(cfg, "", "")
 	go mesh.Start()
 	go func() {
 		<-stop

--- a/test/integrate/case.go
+++ b/test/integrate/case.go
@@ -9,13 +9,13 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/http2"
 	_ "sofastack.io/sofa-mosn/pkg/filter/network/proxy"
 	_ "sofastack.io/sofa-mosn/pkg/filter/network/tcpproxy"
 	"sofastack.io/sofa-mosn/pkg/mosn"
 	"sofastack.io/sofa-mosn/pkg/protocol"
 	"sofastack.io/sofa-mosn/pkg/types"
 	"sofastack.io/sofa-mosn/test/util"
-	"golang.org/x/net/http2"
 )
 
 type TestCase struct {
@@ -49,7 +49,7 @@ func (c *TestCase) StartProxy() {
 	clientMeshAddr := util.CurrentMeshAddr()
 	c.ClientMeshAddr = clientMeshAddr
 	cfg := util.CreateProxyMesh(clientMeshAddr, []string{appAddr}, c.AppProtocol)
-	mesh := mosn.NewMosn(cfg)
+	mesh := mosn.NewMosn(cfg, "", "")
 	go mesh.Start()
 	go func() {
 		<-c.Finish
@@ -68,7 +68,7 @@ func (c *TestCase) Start(tls bool) {
 	c.ClientMeshAddr = clientMeshAddr
 	serverMeshAddr := util.CurrentMeshAddr()
 	cfg := util.CreateMeshToMeshConfig(clientMeshAddr, serverMeshAddr, c.AppProtocol, c.MeshProtocol, []string{appAddr}, tls)
-	mesh := mosn.NewMosn(cfg)
+	mesh := mosn.NewMosn(cfg, "", "")
 	go mesh.Start()
 	go func() {
 		<-c.Finish
@@ -88,7 +88,7 @@ func (c *TestCase) StartX(subprotocol string) {
 	c.ClientMeshAddr = clientMeshAddr
 	serverMeshAddr := util.CurrentMeshAddr()
 	cfg := util.CreateXProtocolMesh(clientMeshAddr, serverMeshAddr, subprotocol, []string{appAddr})
-	mesh := mosn.NewMosn(cfg)
+	mesh := mosn.NewMosn(cfg, "", "")
 	go mesh.Start()
 	go func() {
 		<-c.Finish

--- a/test/integrate/filter/reroute_test.go
+++ b/test/integrate/filter/reroute_test.go
@@ -117,7 +117,7 @@ func TestReRoute(t *testing.T) {
 	httpAddr := httpServer.Addr()
 	meshAddr := util.CurrentMeshAddr()
 	cfg := createInjectProxyMesh(meshAddr, []string{httpAddr}, protocol.HTTP1)
-	mesh := mosn.NewMosn(cfg)
+	mesh := mosn.NewMosn(cfg, "", "")
 	go mesh.Start()
 	defer mesh.Close()
 	time.Sleep(2 * time.Second) // wait mosn start

--- a/test/integrate/functiontest/direct_test.go
+++ b/test/integrate/functiontest/direct_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/http2"
 	"sofastack.io/sofa-mosn/pkg/api/v2"
 	"sofastack.io/sofa-mosn/pkg/config"
 	"sofastack.io/sofa-mosn/pkg/mosn"
@@ -16,7 +17,6 @@ import (
 	"sofastack.io/sofa-mosn/pkg/protocol/rpc/sofarpc"
 	"sofastack.io/sofa-mosn/pkg/types"
 	"sofastack.io/sofa-mosn/test/util"
-	"golang.org/x/net/http2"
 )
 
 // Test Direct Response
@@ -92,7 +92,7 @@ func (c *DirectResponseCase) StartProxy() {
 		Body:       c.body,
 	}
 	cfg := CreateDirectMeshProxy(addr, c.Protocol, resp)
-	mesh := mosn.NewMosn(cfg)
+	mesh := mosn.NewMosn(cfg, "", "")
 	go mesh.Start()
 	go func() {
 		<-c.Finish

--- a/test/integrate/functiontest/faultinject_test.go
+++ b/test/integrate/functiontest/faultinject_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/http2"
 	"sofastack.io/sofa-mosn/pkg/api/v2"
 	"sofastack.io/sofa-mosn/pkg/config"
 	_ "sofastack.io/sofa-mosn/pkg/filter/stream/faultinject"
@@ -19,7 +20,6 @@ import (
 	_ "sofastack.io/sofa-mosn/pkg/stream/sofarpc"
 	"sofastack.io/sofa-mosn/test/integrate"
 	"sofastack.io/sofa-mosn/test/util"
-	"golang.org/x/net/http2"
 )
 
 func AddFaultInject(mosn *config.MOSNConfig, listenername string, faultstr string) error {
@@ -76,7 +76,7 @@ func (c *faultInjectCase) StartProxy() {
 	cfg := util.CreateProxyMesh(clientMeshAddr, []string{appAddr}, c.AppProtocol)
 	faultstr := MakeFaultStr(c.abortstatus, c.delay)
 	AddFaultInject(cfg, "proxyListener", faultstr)
-	mesh := mosn.NewMosn(cfg)
+	mesh := mosn.NewMosn(cfg, "", "")
 	go mesh.Start()
 	go func() {
 		<-c.Finish

--- a/test/integrate/functiontest/keepalive_test.go
+++ b/test/integrate/functiontest/keepalive_test.go
@@ -58,7 +58,7 @@ func TestKeepAlive(t *testing.T) {
 	server.GoServe()
 	clientMeshAddr := util.CurrentMeshAddr()
 	cfg := util.CreateProxyMesh(clientMeshAddr, []string{appAddr}, protocol.SofaRPC)
-	mesh := mosn.NewMosn(cfg)
+	mesh := mosn.NewMosn(cfg, "", "")
 	go mesh.Start()
 	stop := make(chan bool)
 	go func() {

--- a/test/integrate/functiontest/tls_update_test.go
+++ b/test/integrate/functiontest/tls_update_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/http2"
 	"sofastack.io/sofa-mosn/pkg/api/v2"
 	"sofastack.io/sofa-mosn/pkg/config"
 	"sofastack.io/sofa-mosn/pkg/mosn"
@@ -26,7 +27,6 @@ import (
 	_ "sofastack.io/sofa-mosn/pkg/stream/xprotocol"
 	"sofastack.io/sofa-mosn/pkg/types"
 	"sofastack.io/sofa-mosn/test/util"
-	"golang.org/x/net/http2"
 )
 
 const (
@@ -135,7 +135,7 @@ func (c *TLSUpdateCase) Start(tls bool) {
 	cfg := MakeProxyWithTLSConfig(c.ListenerName, c.MeshAddr, []string{appAddr}, c.Protocol, tls)
 	// for test, reset adapter
 	server.ResetAdapter()
-	mesh := mosn.NewMosn(cfg)
+	mesh := mosn.NewMosn(cfg, "", "")
 	go mesh.Start()
 	go func() {
 		<-c.Finish

--- a/test/integrate/functiontest/update_streamfilter_test.go
+++ b/test/integrate/functiontest/update_streamfilter_test.go
@@ -26,7 +26,7 @@ func TestUpdateStreamFilters(t *testing.T) {
 	// create mosn without stream filters
 	clientMeshAddr := util.CurrentMeshAddr()
 	cfg := util.CreateProxyMesh(clientMeshAddr, []string{appAddr}, protocol.SofaRPC)
-	mesh := mosn.NewMosn(cfg)
+	mesh := mosn.NewMosn(cfg, "", "")
 	go mesh.Start()
 	defer mesh.Close()
 	time.Sleep(5 * time.Second)

--- a/test/integrate/protocol_auto_test.go
+++ b/test/integrate/protocol_auto_test.go
@@ -25,7 +25,7 @@ func (c *TestCase) StartAuto(tls bool) {
 	c.ClientMeshAddr = clientMeshAddr
 	serverMeshAddr := util.CurrentMeshAddr()
 	cfg := util.CreateMeshToMeshConfig(clientMeshAddr, serverMeshAddr, protocol.Auto, protocol.Auto, []string{appAddr}, tls)
-	mesh := mosn.NewMosn(cfg)
+	mesh := mosn.NewMosn(cfg, "", "")
 	go mesh.Start()
 	go func() {
 		<-c.Finish
@@ -86,7 +86,7 @@ func TestProtocolHttp2(t *testing.T) {
 	var err error
 
 	magic = http2.ClientPreface
-	prot, err = stream.SelectStreamFactoryProtocol(nil,"", []byte(magic))
+	prot, err = stream.SelectStreamFactoryProtocol(nil, "", []byte(magic))
 	if prot != protocol.HTTP2 {
 		t.Errorf("[ERROR MESSAGE] type error magic : %v\n", magic)
 	}
@@ -97,7 +97,7 @@ func TestProtocolHttp2(t *testing.T) {
 		t.Errorf("[ERROR MESSAGE] type error protocol :%v", err)
 	}
 
-	prot, err = stream.SelectStreamFactoryProtocol(nil,"", []byte("helloworld"))
+	prot, err = stream.SelectStreamFactoryProtocol(nil, "", []byte("helloworld"))
 	if err != stream.FAILED {
 		t.Errorf("[ERROR MESSAGE] type error protocol :%v", err)
 	}
@@ -109,25 +109,25 @@ func TestProtocolHttp1(t *testing.T) {
 	var err error
 
 	magic = "GET"
-	prot, err = stream.SelectStreamFactoryProtocol(nil,"", []byte(magic))
+	prot, err = stream.SelectStreamFactoryProtocol(nil, "", []byte(magic))
 	if prot != protocol.HTTP1 {
 		t.Errorf("[ERROR MESSAGE] type error magic : %v\n", magic)
 	}
 
 	magic = "POST"
-	prot, err = stream.SelectStreamFactoryProtocol(nil,"", []byte(magic))
+	prot, err = stream.SelectStreamFactoryProtocol(nil, "", []byte(magic))
 	if prot != protocol.HTTP1 {
 		t.Errorf("[ERROR MESSAGE] type error magic : %v\n", magic)
 	}
 
 	magic = "POS"
-	prot, err = stream.SelectStreamFactoryProtocol(nil,"", []byte(magic))
+	prot, err = stream.SelectStreamFactoryProtocol(nil, "", []byte(magic))
 	if err != stream.EAGAIN {
 		t.Errorf("[ERROR MESSAGE] type error protocol :%v", err)
 	}
 
 	magic = "PPPPPPP"
-	prot, err = stream.SelectStreamFactoryProtocol(nil,"", []byte(magic))
+	prot, err = stream.SelectStreamFactoryProtocol(nil, "", []byte(magic))
 	if err != stream.FAILED {
 		t.Errorf("[ERROR MESSAGE] type error protocol :%v", err)
 	}

--- a/test/integrate/retry_test.go
+++ b/test/integrate/retry_test.go
@@ -60,7 +60,7 @@ func (c *RetryCase) StartProxy() {
 	clientMeshAddr := util.CurrentMeshAddr()
 	c.ClientMeshAddr = clientMeshAddr
 	cfg := util.CreateProxyMesh(clientMeshAddr, []string{app1, app2}, c.AppProtocol)
-	mesh := mosn.NewMosn(cfg)
+	mesh := mosn.NewMosn(cfg, "", "")
 	go mesh.Start()
 	go func() {
 		<-c.Finish
@@ -87,7 +87,7 @@ func (c *RetryCase) Start(tls bool) {
 	c.ClientMeshAddr = clientMeshAddr
 	serverMeshAddr := util.CurrentMeshAddr()
 	cfg := util.CreateMeshToMeshConfig(clientMeshAddr, serverMeshAddr, c.AppProtocol, c.MeshProtocol, []string{app1, app2}, tls)
-	mesh := mosn.NewMosn(cfg)
+	mesh := mosn.NewMosn(cfg, "", "")
 	go mesh.Start()
 	go func() {
 		<-c.Finish

--- a/test/integrate/router_with_weight_test.go
+++ b/test/integrate/router_with_weight_test.go
@@ -57,7 +57,7 @@ func (c *weightCase) Start() {
 	meshAddr := testutil.CurrentMeshAddr()
 	c.ClientMeshAddr = meshAddr
 	cfg := testutil.CreateWeightProxyMesh(meshAddr, protocol.SofaRPC, c.clusters)
-	mesh := mosn.NewMosn(cfg)
+	mesh := mosn.NewMosn(cfg, "", "")
 	go mesh.Start()
 	go func() {
 		<-c.Finish

--- a/test/integrate/tcpproxy_test.go
+++ b/test/integrate/tcpproxy_test.go
@@ -20,7 +20,7 @@ func (c *tcpExtendCase) Start(isRouteEntryMode bool) {
 	meshAddr := testutil.CurrentMeshAddr()
 	c.ClientMeshAddr = meshAddr
 	cfg := testutil.CreateTCPProxyConfig(meshAddr, []string{appAddr}, isRouteEntryMode)
-	mesh := mosn.NewMosn(cfg)
+	mesh := mosn.NewMosn(cfg, "", "")
 	go mesh.Start()
 	go func() {
 		<-c.Finish

--- a/test/integrate/tls_extend_test.go
+++ b/test/integrate/tls_extend_test.go
@@ -96,7 +96,7 @@ func (c *tlsExtendCase) Start(conf *testutil.ExtendVerifyConfig) {
 	c.ClientMeshAddr = clientMeshAddr
 	serverMeshAddr := testutil.CurrentMeshAddr()
 	cfg := testutil.CreateTLSExtensionConfig(clientMeshAddr, serverMeshAddr, c.AppProtocol, c.MeshProtocol, []string{appAddr}, conf)
-	mesh := mosn.NewMosn(cfg)
+	mesh := mosn.NewMosn(cfg, "", "")
 	go mesh.Start()
 	go func() {
 		<-c.Finish

--- a/test/integrate/transfer/transfer_test.go
+++ b/test/integrate/transfer/transfer_test.go
@@ -61,7 +61,7 @@ func startTransferMesh(t *testing.T, tc *integrate.TestCase) {
 	// set config path into load package
 	config.Load(configPath)
 
-	mesh := mosn.NewMosn(cfg)
+	mesh := mosn.NewMosn(cfg, "", "")
 
 	log.InitDefaultLogger("", log.DEBUG)
 

--- a/test/integrate/xds_config_test.go
+++ b/test/integrate/xds_config_test.go
@@ -119,7 +119,7 @@ func TestConfigAddAndUpdate(t *testing.T) {
 	mosnConfig := config.Load(filepath.Join("testdata", "envoy.json"))
 	admin.Reset()
 	admin.SetMOSNConfig(mosnConfig)
-	Mosn := mosn.NewMosn(mosnConfig)
+	Mosn := mosn.NewMosn(mosnConfig, "", "")
 	Mosn.Start()
 
 	buf, err := admin.Dump()

--- a/test/metrics/proxy.go
+++ b/test/metrics/proxy.go
@@ -43,7 +43,7 @@ func main() {
 		return
 	}
 	cfg := util.CreateProxyMesh(meshAddr, []string{serverAddr}, proto)
-	mesh := mosn.NewMosn(cfg)
+	mesh := mosn.NewMosn(cfg, "", "")
 	go mesh.Start()
 	go server.Start()
 	// Proxy API


### PR DESCRIPTION
Adjust the timing of XDS client startup to ensure that XDS starts pulling rules before parsing the necessary configuration files