### PR TITLE
the write connection buf is not check nil

### DIFF
--- a/pkg/network/connection.go
+++ b/pkg/network/connection.go
@@ -594,6 +594,9 @@ func (c *connection) writeDirectly(buf *[]types.IoBuffer) (err error) {
 	netBufferPool.Put(netBuffer)
 
 	for _, buf := range *buf {
+		if buf == nil {
+			continue
+		}
 		if buf.EOF() {
 			err = buffer.EOF
 		}


### PR DESCRIPTION
n pkg/network/connection.go

for _, buf := range *buf {
//check the buf is or not nil
if buf == nil {
continue
}
writeBuffer = append(writeBuffer, buf.Bytes())
writeBufferLen += int64(buf.Len())
}
but
for _, buf := range *buf {
//not check buf is nil
if buf.EOF() {
err = buffer.EOF
}
if e := buffer.PutIoBuffer(buf); e != nil {
log.DefaultLogger.Errorf("[network] [write directly] PutIoBuffer error: %v", e)
}
}
