### PR TITLE
check buf is nil

### DIFF
--- a/pkg/network/connection.go
+++ b/pkg/network/connection.go
@@ -594,6 +594,9 @@ func (c *connection) writeDirectly(buf *[]types.IoBuffer) (err error) {
 	netBufferPool.Put(netBuffer)
 
 	for _, buf := range *buf {
+		if buf == nil {
+			continue
+		}
 		if buf.EOF() {
 			err = buffer.EOF
 		}


### PR DESCRIPTION
### Issues associated with this PR
 pkg/network/connection.go

for _, buf := range *buf {
//check the buf is or not nil
if buf == nil {
continue
}
writeBuffer = append(writeBuffer, buf.Bytes())
writeBufferLen += int64(buf.Len())
}
but
for _, buf := range *buf {
//not check buf is nil
if buf.EOF() {
err = buffer.EOF
}
if e := buffer.PutIoBuffer(buf); e != nil {
log.DefaultLogger.Errorf("[network] [write directly] PutIoBuffer error: %v", e)
}
}
Your PR should present related issues you want to solve.

### Sign the CLA
Make sure you have signed the [CLA](http://cla.sofastack.tech)

### Solutions
You should show your solutions about the issues in your PR, including the overall solutions, 
details and the changes. At this time, Chinese is allowed to describe these.

### UT result
Unit Test is needed if the code is changed, your unit test should cover boundary cases, corner cases, and some exceptional cases.
And you need to show the ut result.

### Benchmark
If your code involves the processing of every request, you should give the Benchmark Result

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
