### PR TITLE
fix mosn example image

### DIFF
--- a/build/contrib/builder/image/Dockerfile
+++ b/build/contrib/builder/image/Dockerfile
@@ -1,23 +1,29 @@
+FROM centos:centos7 as builder
+
+ENV CHROOT_MOSN_PREFIX         /ROOT/home/admin/mosn
+RUN useradd -ms /bin/bash admin
+
+COPY ./etc/supervisor/supervisord.conf            /ROOT/etc/supervisord.conf
+COPY ./etc/supervisor/mosn.conf                   /ROOT/etc/supervisord/conf.d/mosn.conf
+
+COPY ./mosnd $CHROOT_MOSN_PREFIX/bin/mosn
+
+RUN mkdir -p $MOSN_PREFIX/conf \
+ && mkdir -p $MOSN_PREFIX/logs
+
+COPY ./configs/mosn_config.json $CHROOT_MOSN_PREFIX/conf/mosn_config.json
+
+RUN chmod +x $CHROOT_MOSN_PREFIX/bin/mosn
+RUN chown -R admin:admin /ROOT/home/admin
+
+
 FROM centos:centos7
-MAINTAINER  xiaodong.dxd@alibaba-inc.com
-
 ENV TMP_FOLDER      /tmp
-ENV GIT_USER        alipay
-ENV MOSN_PREFIX     /home/admin/mosn
-ENV PATH            $MOSN_PREFIX/sbin:$PATH
-
-RUN mkdir -p $MOSN_PREFIX/conf
-RUN mkdir -p $MOSN_PREFIX/logs
 
 RUN yum install -y \
        ssh wget curl perl logrotate make build-essential procps \
        tsar tcpdump mpstat iostat vmstat sysstat \
        python-setuptools; yum clean all
-
-# 规避crond在docker环境下运行的问题
-RUN echo -e "sleep 10;/bin/touch /var/spool/cron/a;/bin/rm -f /var/spool/cron/a;service crond restart" > /opt/fix-cron.sh
-
-COPY ./etc/script/entrypoint.sh     /usr/local/bin/entrypoint.sh
 
 # pip
 WORKDIR $TMP_FOLDER
@@ -30,16 +36,11 @@ RUN python setup.py install
 RUN pip install supervisor -i https://mirrors.aliyun.com/pypi/simple
 RUN pip install supervisor-stdout -i https://mirrors.aliyun.com/pypi/simple
 
-RUN echo "export MOSN_PREFIX=/home/admin/mosn" >> /etc/bashrc;
-RUN echo "export PATH=$PATH" >> /etc/bashrc
+RUN useradd -ms /bin/bash admin
+# copy all in one layer
+COPY --from=builder /ROOT /
 
-COPY ./etc/supervisor/supervisord.conf            /etc/supervisord.conf
-COPY ./etc/supervisor/mosn.conf                   /etc/supervisord/conf.d/mosn.conf
-COPY ./etc/mosn/mosn.logrotate                    /etc/logrotate.d/mosn
-RUN mv /etc/cron.daily/logrotate                  /etc/cron.hourly/logrotate
-
-EXPOSE 22 80
-
-ADD ./mosnd $MOSN_PREFIX/sbin
+RUN echo "export MOSN_PREFIX=/home/admin/mosn" >> /etc/bashrc \
+ && echo "export PATH=$PATH" >> /etc/bashrc
 
 ENTRYPOINT ["/usr/bin/supervisord" , "-c" , "/etc/supervisord.conf"]

--- a/configs/mosn_config.json
+++ b/configs/mosn_config.json
@@ -122,7 +122,7 @@
           "log_level": "DEBUG",
           "access_logs": [
             {
-              "log_path": "./access_ingress.log",
+              "log_path": "/home/admin/mosn/logs/access_ingress.log",
               "log_format": "%StartTime% %RequestReceivedDuration% %ResponseReceivedDuration% %REQ.requestid% %REQ.cmdcode% %RESP.requestid% %RESP.service%"
             }
           ]

--- a/etc/supervisor/mosn.conf
+++ b/etc/supervisor/mosn.conf
@@ -1,5 +1,5 @@
 [program:mosn]
-command=mosnd start -c /home/admin/mosn/conf/mosn.conf
+command=/home/admin/mosn/bin/mosn start -c /home/admin/mosn/conf/mosn_config.json
 user=admin
 startsecs=1
 autostart=true

--- a/etc/supervisor/supervisord.conf
+++ b/etc/supervisor/supervisord.conf
@@ -10,15 +10,6 @@
 
 [unix_http_server]
 file=/dev/shm/supervisor.sock
-;chmod=0700                 ; socket file mode (default 0700)
-;chown=nobody:nogroup       ; socket file uid:gid owner
-;username=user              ; (default is no username (open server))
-;password=123               ; (default is no password (open server))
-
-;[inet_http_server]         ; inet (TCP) server disabled by default
-;port=127.0.0.1:9001        ; (ip_address:port specifier, *:port for all iface)
-;username=user              ; (default is no username (open server))
-;password=123               ; (default is no password (open server))
 
 [supervisord]
 logfile=/tmp/supervisord.log ; (main log file;default $CWD/supervisord.log)
@@ -29,14 +20,6 @@ pidfile=/tmp/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
 nodaemon=true                ; (start in foreground if true;default false)
 minfds=1024                  ; (min. avail startup file descriptors;default 1024)
 minprocs=200                 ; (min. avail process descriptors;default 200)
-;umask=022                   ; (process file creation umask;default 022)
-;user=chrism                 ; (default is current user, required if root)
-;identifier=supervisor       ; (supervisord identifier, default is 'supervisor')
-;directory=/tmp              ; (default is not to cd during start)
-;nocleanup=true              ; (don't clean up tempfiles at start;default false)
-;childlogdir=/tmp            ; ('AUTO' child log dir, default $TEMP)
-;environment=KEY="value"     ; (key value pairs to add to environment)
-;strip_ansi=false            ; (strip ansi escape codes in logs; def. false)
 
 ; the below section must remain in the config file for RPC
 ; (supervisorctl/web interface) to work, additional interfaces may be
@@ -46,96 +29,6 @@ supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [supervisorctl]
 serverurl=unix:///dev/shm/supervisor.sock
-;serverurl=http://127.0.0.1:9001 ; use an http:// url to specify an inet socket
-;username=chris              ; should be same as http_username if set
-;password=123                ; should be same as http_password if set
-;prompt=mysupervisor         ; cmd line prompt (default "supervisor")
-;history_file=~/.sc_history  ; use readline history if available
-
-; The below sample program section shows all possible program subsection values,
-; create one or more 'real' program: sections to be able to control them under
-; supervisor.
-
-;[program:theprogramname]
-;command=/bin/cat              ; the program (relative uses PATH, can take args)
-;process_name=%(program_name)s ; process_name expr (default %(program_name)s)
-;numprocs=1                    ; number of processes copies to start (def 1)
-;directory=/tmp                ; directory to cwd to before exec (def no cwd)
-;umask=022                     ; umask for process (default None)
-;priority=999                  ; the relative start priority (default 999)
-;autostart=true                ; start at supervisord start (default: true)
-;startsecs=1                   ; # of secs prog must stay up to be running (def. 1)
-;startretries=3                ; max # of serial start failures when starting (default 3)
-;autorestart=unexpected        ; when to restart if exited after running (def: unexpected)
-;exitcodes=0,2                 ; 'expected' exit codes used with autorestart (default 0,2)
-;stopsignal=QUIT               ; signal used to kill process (default TERM)
-;stopwaitsecs=10               ; max num secs to wait b4 SIGKILL (default 10)
-;stopasgroup=false             ; send stop signal to the UNIX process group (default false)
-;killasgroup=false             ; SIGKILL the UNIX process group (def false)
-;user=chrism                   ; setuid to this UNIX account to run the program
-;redirect_stderr=true          ; redirect proc stderr to stdout (default false)
-;stdout_logfile=/a/path        ; stdout log path, NONE for none; default AUTO
-;stdout_logfile_maxbytes=1MB   ; max # logfile bytes b4 rotation (default 50MB)
-;stdout_logfile_backups=10     ; # of stdout logfile backups (default 10)
-;stdout_capture_maxbytes=1MB   ; number of bytes in 'capturemode' (default 0)
-;stdout_events_enabled=false   ; emit events on stdout writes (default false)
-;stderr_logfile=/a/path        ; stderr log path, NONE for none; default AUTO
-;stderr_logfile_maxbytes=1MB   ; max # logfile bytes b4 rotation (default 50MB)
-;stderr_logfile_backups=10     ; # of stderr logfile backups (default 10)
-;stderr_capture_maxbytes=1MB   ; number of bytes in 'capturemode' (default 0)
-;stderr_events_enabled=false   ; emit events on stderr writes (default false)
-;environment=A="1",B="2"       ; process environment additions (def no adds)
-;serverurl=AUTO                ; override serverurl computation (childutils)
-
-; The below sample eventlistener section shows all possible
-; eventlistener subsection values, create one or more 'real'
-; eventlistener: sections to be able to handle event notifications
-; sent by supervisor.
-
-;[eventlistener:theeventlistenername]
-;command=/bin/eventlistener    ; the program (relative uses PATH, can take args)
-;process_name=%(program_name)s ; process_name expr (default %(program_name)s)
-;numprocs=1                    ; number of processes copies to start (def 1)
-;events=EVENT                  ; event notif. types to subscribe to (req'd)
-;buffer_size=10                ; event buffer queue size (default 10)
-;directory=/tmp                ; directory to cwd to before exec (def no cwd)
-;umask=022                     ; umask for process (default None)
-;priority=-1                   ; the relative start priority (default -1)
-;autostart=true                ; start at supervisord start (default: true)
-;startsecs=1                   ; # of secs prog must stay up to be running (def. 1)
-;startretries=3                ; max # of serial start failures when starting (default 3)
-;autorestart=unexpected        ; autorestart if exited after running (def: unexpected)
-;exitcodes=0,2                 ; 'expected' exit codes used with autorestart (default 0,2)
-;stopsignal=QUIT               ; signal used to kill process (default TERM)
-;stopwaitsecs=10               ; max num secs to wait b4 SIGKILL (default 10)
-;stopasgroup=false             ; send stop signal to the UNIX process group (default false)
-;killasgroup=false             ; SIGKILL the UNIX process group (def false)
-;user=chrism                   ; setuid to this UNIX account to run the program
-;redirect_stderr=false         ; redirect_stderr=true is not allowed for eventlisteners
-;stdout_logfile=/a/path        ; stdout log path, NONE for none; default AUTO
-;stdout_logfile_maxbytes=1MB   ; max # logfile bytes b4 rotation (default 50MB)
-;stdout_logfile_backups=10     ; # of stdout logfile backups (default 10)
-;stdout_events_enabled=false   ; emit events on stdout writes (default false)
-;stderr_logfile=/a/path        ; stderr log path, NONE for none; default AUTO
-;stderr_logfile_maxbytes=1MB   ; max # logfile bytes b4 rotation (default 50MB)
-;stderr_logfile_backups=10     ; # of stderr logfile backups (default 10)
-;stderr_events_enabled=false   ; emit events on stderr writes (default false)
-;environment=A="1",B="2"       ; process environment additions
-;serverurl=AUTO                ; override serverurl computation (childutils)
-
-; The below sample group section shows all possible group values,
-; create one or more 'real' group: sections to create "heterogeneous"
-; process groups.
-
-;[group:thegroupname]
-;programs=progname1,progname2  ; each refers to 'x' in [program:x] definitions
-;priority=999                  ; the relative start priority (default 999)
-
-; The [include] section can just contain the "files" setting.  This
-; setting can list multiple files (separated by whitespace or
-; newlines).  It can also contain wildcards.  The filenames are
-; interpreted as relative to this file.  Included files *cannot*
-; include files themselves.
 
 [eventlistener:stdout]
 command = supervisor_stdout
@@ -145,19 +38,3 @@ result_handler = supervisor_stdout:event_handler
 
 [include]
 files = /etc/supervisord/conf.d/*.conf
-
-[program:crond]
-command = /etc/init.d/crond start
-priority = 10
-autorestart = unexpected
-
-[program:sshd]
-command=/usr/sbin/sshd -D
-
-[program:rsyslog]
-command = /etc/init.d/rsyslog start
-
-[program:fix-cron]
-command = sh /opt/fix-cron.sh
-startretries = 0
-autorestart = false


### PR DESCRIPTION
fix #889 

mosn image is just a example. Usually, we just run example with binary, not image

make build  && make image
docker run -dit ${docker image}

