### PR TITLE
fix memleak when proxy goroutine panic

### DIFF
--- a/pkg/proxy/downstream.go
+++ b/pkg/proxy/downstream.go
@@ -335,7 +335,6 @@ func (s *downStream) OnReceive(ctx context.Context, headers types.HeaderMap, dat
 					r, s, id, s.ID, string(debug.Stack()))
 
 				if id == s.ID {
-					s.writeLog()
 					s.delete()
 				}
 			}

--- a/pkg/proxy/downstream.go
+++ b/pkg/proxy/downstream.go
@@ -208,8 +208,8 @@ func (s *downStream) cleanStream() {
 	// write access log
 	s.writeLog()
 
-	// delete stream
-	s.proxy.deleteActiveStream(s)
+	// delete stream reference
+	s.delete()
 
 	// recycle if no reset events
 	s.giveStream()
@@ -285,6 +285,12 @@ func (s *downStream) writeLog() {
 	}
 }
 
+func (s *downStream) delete() {
+	if s.proxy != nil {
+		s.proxy.deleteActiveStream(s)
+	}
+}
+
 // types.StreamEventListener
 // Called by stream layer normally
 func (s *downStream) OnResetStream(reason types.StreamResetReason) {
@@ -330,6 +336,7 @@ func (s *downStream) OnReceive(ctx context.Context, headers types.HeaderMap, dat
 
 				if id == s.ID {
 					s.writeLog()
+					s.delete()
 				}
 			}
 		}()

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -255,6 +255,7 @@ func (p *proxy) deleteActiveStream(s *downStream) {
 		p.asMux.Lock()
 		p.activeSteams.Remove(s.element)
 		p.asMux.Unlock()
+		s.element = nil
 	}
 }
 


### PR DESCRIPTION
### Issues associated with this PR 

Your PR should present related issues you want to solve.

### Sign the CLA
Make sure you have signed the [CLA](http://cla.sofastack.tech)

### Solutions
当请求在proxy协程处理的时候panic了，比如streamfilter逻辑有问题，这个时候不会执行cleanStream的逻辑，不会删除downstream在proxy的list中的引用，导致内存不能被gc掉。
修复方法：
在panic的recover中，主动去删除这个引用关系，让gc能释放内存

### UT result
Unit Test is needed if the code is changed, your unit test should cover boundary cases, corner cases, and some exceptional cases.
And you need to show the ut result.

### Benchmark
If your code involves the processing of every request, you should give the Benchmark Result

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
